### PR TITLE
feat: use string union instead of enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ class MyAgentExecutor implements AgentExecutor {
         taskId: taskId,
         contextId: contextId,
         status: {
-          state: "canceled",
+          state: 'canceled',
           timestamp: new Date().toISOString(),
         },
         final: true,
@@ -191,7 +191,7 @@ class MyAgentExecutor implements AgentExecutor {
       taskId: taskId,
       contextId: contextId,
       status: {
-        state: "completed",
+        state: 'completed',
         message: {
           kind: 'message',
           role: 'agent',

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ import {
   A2AExpressApp,
   AgentExecutor,
   RequestContext,
-  IExecutionEventBus,
+  ExecutionEventBus,
   DefaultRequestHandler,
 } from "@a2a-js/sdk";
 
@@ -90,7 +90,7 @@ class MyAgentExecutor implements AgentExecutor {
 
   public cancelTask = async (
         taskId: string,
-        eventBus: IExecutionEventBus,
+        eventBus: ExecutionEventBus,
     ): Promise<void> => {
         this.cancelledTasks.add(taskId);
         // The execute loop is responsible for publishing the final state
@@ -98,7 +98,7 @@ class MyAgentExecutor implements AgentExecutor {
 
   async execute(
     requestContext: RequestContext,
-    eventBus: IExecutionEventBus
+    eventBus: ExecutionEventBus
   ): Promise<void> {
     const userMessage = requestContext.userMessage;
     const existingTask = requestContext.task;
@@ -118,7 +118,7 @@ class MyAgentExecutor implements AgentExecutor {
         id: taskId,
         contextId: contextId,
         status: {
-          state: TaskState.Submitted,
+          state: 'submitted',
           timestamp: new Date().toISOString(),
         },
         history: [userMessage],
@@ -134,7 +134,7 @@ class MyAgentExecutor implements AgentExecutor {
       taskId: taskId,
       contextId: contextId,
       status: {
-        state: TaskState.Working,
+        state: 'working',
         message: {
           kind: 'message',
           role: 'agent',
@@ -160,7 +160,7 @@ class MyAgentExecutor implements AgentExecutor {
         taskId: taskId,
         contextId: contextId,
         status: {
-          state: TaskState.Canceled,
+          state: "canceled",
           timestamp: new Date().toISOString(),
         },
         final: true,
@@ -191,7 +191,7 @@ class MyAgentExecutor implements AgentExecutor {
       taskId: taskId,
       contextId: contextId,
       status: {
-        state: TaskState.Completed,
+        state: "completed",
         message: {
           kind: 'message',
           role: 'agent',

--- a/scripts/generateTypes.js
+++ b/scripts/generateTypes.js
@@ -2,20 +2,8 @@ import { compile, compileFromFile } from 'json-schema-to-typescript'
 import fs from 'fs';
 import path from 'path';
 
-function clearAndUpper(text) {
-  return text.replace(/-/, "").toUpperCase();
-}
-
-function toPascalCase(text) {
-  return text.replace(/(^\w|-\w)/g, clearAndUpper);
-}
-
 const typeSchemaContents = fs.readFileSync(path.join(process.cwd(), 'spec.json'), 'utf8');
 const typeSchema = JSON.parse(typeSchemaContents.toString());
-
-// Manually injecting TaskState enum names in pascal case.
-// https://github.com/bcherny/json-schema-to-typescript/tree/master?tab=readme-ov-file#custom-schema-properties
-typeSchema.definitions.TaskState["tsEnumNames"] = typeSchema.definitions.TaskState.enum.map(name => toPascalCase(name))
 
 compile(typeSchema, 'MySchema', {
     additionalProperties: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,10 @@
 export type { AgentExecutor } from "./server/agent_execution/agent_executor.js";
 export { RequestContext } from "./server/agent_execution/request_context.js";
 
-export type { IExecutionEventBus } from "./server/events/execution_event_bus.js";
-export { ExecutionEventBus } from "./server/events/execution_event_bus.js";
-export type { IExecutionEventBusManager } from "./server/events/execution_event_bus_manager.js";
-export { ExecutionEventBusManager } from "./server/events/execution_event_bus_manager.js";
+export type { ExecutionEventBus } from "./server/events/execution_event_bus.js";
+export { DefaultExecutionEventBus } from "./server/events/execution_event_bus.js";
+export type { ExecutionEventBusManager } from "./server/events/execution_event_bus_manager.js";
+export { DefaultExecutionEventBusManager } from "./server/events/execution_event_bus_manager.js";
 
 export type { A2ARequestHandler } from "./server/request_handler/a2a_request_handler.js";
 export { DefaultRequestHandler } from "./server/request_handler/default_request_handler.js";

--- a/src/samples/agents/movie-agent/index.ts
+++ b/src/samples/agents/movie-agent/index.ts
@@ -162,7 +162,7 @@ class MovieAgentExecutor implements AgentExecutor {
           taskId: taskId,
           contextId: contextId,
           status: {
-            state: "canceled",
+            state: 'canceled',
             timestamp: new Date().toISOString(),
           },
           final: true, // Cancellation is a final state
@@ -180,14 +180,14 @@ class MovieAgentExecutor implements AgentExecutor {
       let finalA2AState: TaskState = "unknown";
 
       if (finalStateLine === 'COMPLETED') {
-        finalA2AState = "completed";
+        finalA2AState = 'completed';
       } else if (finalStateLine === 'AWAITING_USER_INPUT') {
-        finalA2AState = "input-required";
+        finalA2AState = 'input-required';
       } else {
         console.warn(
           `[MovieAgentExecutor] Unexpected final state line from prompt: ${finalStateLine}. Defaulting to 'completed'.`
         );
-        finalA2AState = "completed"; // Default if LLM deviates
+        finalA2AState = 'completed'; // Default if LLM deviates
       }
 
       // 5. Publish final task status update
@@ -229,7 +229,7 @@ class MovieAgentExecutor implements AgentExecutor {
         taskId: taskId,
         contextId: contextId,
         status: {
-          state: "failed",
+          state: 'failed',
           message: {
             kind: 'message',
             role: 'agent',

--- a/src/samples/agents/movie-agent/index.ts
+++ b/src/samples/agents/movie-agent/index.ts
@@ -7,7 +7,7 @@ import {
   A2AExpressApp,
   AgentExecutor,
   RequestContext,
-  IExecutionEventBus,
+  ExecutionEventBus,
   DefaultRequestHandler,
   AgentCard,
   Task,
@@ -39,7 +39,7 @@ class MovieAgentExecutor implements AgentExecutor {
 
   public cancelTask = async (
         taskId: string,
-        eventBus: IExecutionEventBus,
+        eventBus: ExecutionEventBus,
     ): Promise<void> => {
         this.cancelledTasks.add(taskId);
         // The execute loop is responsible for publishing the final state
@@ -47,7 +47,7 @@ class MovieAgentExecutor implements AgentExecutor {
 
   async execute(
     requestContext: RequestContext,
-    eventBus: IExecutionEventBus
+    eventBus: ExecutionEventBus
   ): Promise<void> {
     const userMessage = requestContext.userMessage;
     const existingTask = requestContext.task;

--- a/src/samples/agents/movie-agent/index.ts
+++ b/src/samples/agents/movie-agent/index.ts
@@ -67,7 +67,7 @@ class MovieAgentExecutor implements AgentExecutor {
         id: taskId,
         contextId: contextId,
         status: {
-          state: TaskState.Submitted,
+          state: 'submitted',
           timestamp: new Date().toISOString(),
         },
         history: [userMessage], // Start history with the current user message
@@ -82,7 +82,7 @@ class MovieAgentExecutor implements AgentExecutor {
       taskId: taskId,
       contextId: contextId,
       status: {
-        state: TaskState.Working,
+        state: 'working',
         message: {
           kind: 'message',
           role: 'agent',
@@ -124,7 +124,7 @@ class MovieAgentExecutor implements AgentExecutor {
         taskId: taskId,
         contextId: contextId,
         status: {
-          state: TaskState.Failed,
+          state: 'failed',
           message: {
             kind: 'message',
             role: 'agent',
@@ -162,7 +162,7 @@ class MovieAgentExecutor implements AgentExecutor {
           taskId: taskId,
           contextId: contextId,
           status: {
-            state: TaskState.Canceled,
+            state: "canceled",
             timestamp: new Date().toISOString(),
           },
           final: true, // Cancellation is a final state
@@ -177,17 +177,17 @@ class MovieAgentExecutor implements AgentExecutor {
       const finalStateLine = lines.at(-1)?.trim().toUpperCase();
       const agentReplyText = lines.slice(0, lines.length - 1).join('\n').trim();
 
-      let finalA2AState: TaskState = TaskState.Unknown;
+      let finalA2AState: TaskState = "unknown";
 
       if (finalStateLine === 'COMPLETED') {
-        finalA2AState = TaskState.Completed;
+        finalA2AState = "completed";
       } else if (finalStateLine === 'AWAITING_USER_INPUT') {
-        finalA2AState = TaskState.InputRequired;
+        finalA2AState = "input-required";
       } else {
         console.warn(
           `[MovieAgentExecutor] Unexpected final state line from prompt: ${finalStateLine}. Defaulting to 'completed'.`
         );
-        finalA2AState = TaskState.Completed; // Default if LLM deviates
+        finalA2AState = "completed"; // Default if LLM deviates
       }
 
       // 5. Publish final task status update
@@ -229,7 +229,7 @@ class MovieAgentExecutor implements AgentExecutor {
         taskId: taskId,
         contextId: contextId,
         status: {
-          state: TaskState.Failed,
+          state: "failed",
           message: {
             kind: 'message',
             role: 'agent',

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -278,7 +278,7 @@ async function main() {
           printAgentEvent(typedEvent);
 
           // If the event is a TaskStatusUpdateEvent and it's final, reset currentTaskId
-          if (typedEvent.kind === "status-update" && (typedEvent as TaskStatusUpdateEvent).final && (typedEvent as TaskStatusUpdateEvent).status.state !== TaskState.InputRequired) {
+          if (typedEvent.kind === "status-update" && (typedEvent as TaskStatusUpdateEvent).final && (typedEvent as TaskStatusUpdateEvent).status.state !== "input-required") {
             console.log(colorize("yellow", `   Task ${typedEvent.taskId} is final. Clearing current task ID.`));
             currentTaskId = undefined;
             // Optionally, you might want to clear currentContextId as well if a task ending implies context ending.

--- a/src/server/agent_execution/agent_executor.ts
+++ b/src/server/agent_execution/agent_executor.ts
@@ -1,4 +1,4 @@
-import { IExecutionEventBus } from "../events/execution_event_bus.js";
+import { ExecutionEventBus } from "../events/execution_event_bus.js";
 import { RequestContext } from "./request_context.js";
 
 export interface AgentExecutor {
@@ -9,7 +9,7 @@ export interface AgentExecutor {
      */
     execute: (
         requestContext: RequestContext,
-        eventBus: IExecutionEventBus
+        eventBus: ExecutionEventBus
     ) => Promise<void>;
 
     /**
@@ -21,6 +21,6 @@ export interface AgentExecutor {
      */
     cancelTask: (
         taskId: string,
-        eventBus: IExecutionEventBus
+        eventBus: ExecutionEventBus
     ) => Promise<void>;
 }

--- a/src/server/events/execution_event_bus.ts
+++ b/src/server/events/execution_event_bus.ts
@@ -13,7 +13,7 @@ export type AgentExecutionEvent =
     | TaskStatusUpdateEvent
     | TaskArtifactUpdateEvent;
 
-export interface IExecutionEventBus {
+export interface ExecutionEventBus {
     publish(event: AgentExecutionEvent): void;
     on(eventName: 'event' | 'finished', listener: (event: AgentExecutionEvent) => void): this;
     off(eventName: 'event' | 'finished', listener: (event: AgentExecutionEvent) => void): this;
@@ -22,7 +22,7 @@ export interface IExecutionEventBus {
     finished(): void;
 }
 
-export class ExecutionEventBus extends EventEmitter implements IExecutionEventBus {
+export class DefaultExecutionEventBus extends EventEmitter implements ExecutionEventBus {
     constructor() {
         super();
     }

--- a/src/server/events/execution_event_bus_manager.ts
+++ b/src/server/events/execution_event_bus_manager.ts
@@ -1,22 +1,22 @@
-import { ExecutionEventBus, IExecutionEventBus } from "./execution_event_bus.js";
+import { DefaultExecutionEventBus, ExecutionEventBus } from "./execution_event_bus.js";
 
-export interface IExecutionEventBusManager {
-    createOrGetByTaskId(taskId: string): IExecutionEventBus;
-    getByTaskId(taskId: string): IExecutionEventBus | undefined;
+export interface ExecutionEventBusManager {
+    createOrGetByTaskId(taskId: string): ExecutionEventBus;
+    getByTaskId(taskId: string): ExecutionEventBus | undefined;
     cleanupByTaskId(taskId: string): void;
 }
 
-export class ExecutionEventBusManager implements IExecutionEventBusManager {
-    private taskIdToBus: Map<string, IExecutionEventBus> = new Map();
+export class DefaultExecutionEventBusManager implements ExecutionEventBusManager {
+    private taskIdToBus: Map<string, ExecutionEventBus> = new Map();
 
     /**
      * Creates or retrieves an existing ExecutionEventBus based on the taskId.
      * @param taskId The ID of the task.
      * @returns An instance of IExecutionEventBus.
      */
-    public createOrGetByTaskId(taskId: string): IExecutionEventBus {
+    public createOrGetByTaskId(taskId: string): ExecutionEventBus {
         if (!this.taskIdToBus.has(taskId)) {
-            this.taskIdToBus.set(taskId, new ExecutionEventBus());
+            this.taskIdToBus.set(taskId, new DefaultExecutionEventBus());
         }
         return this.taskIdToBus.get(taskId)!;
     }
@@ -26,7 +26,7 @@ export class ExecutionEventBusManager implements IExecutionEventBusManager {
      * @param taskId The ID of the task.
      * @returns An instance of IExecutionEventBus or undefined if not found.
      */
-    public getByTaskId(taskId: string): IExecutionEventBus | undefined {
+    public getByTaskId(taskId: string): ExecutionEventBus | undefined {
         return this.taskIdToBus.get(taskId);
     }
 

--- a/src/server/events/execution_event_queue.ts
+++ b/src/server/events/execution_event_queue.ts
@@ -1,20 +1,20 @@
 import {
     TaskStatusUpdateEvent,
 } from "../../types.js";
-import { IExecutionEventBus, AgentExecutionEvent } from "./execution_event_bus.js";
+import { ExecutionEventBus, AgentExecutionEvent } from "./execution_event_bus.js";
 
 /**
  * An async queue that subscribes to an ExecutionEventBus for events
  * and provides an async generator to consume them.
  */
 export class ExecutionEventQueue {
-    private eventBus: IExecutionEventBus;
+    private eventBus: ExecutionEventBus;
     private eventQueue: AgentExecutionEvent[] = [];
     private resolvePromise?: (value: void | PromiseLike<void>) => void;
     private stopped: boolean = false;
     private boundHandleEvent: (event: AgentExecutionEvent) => void;
 
-    constructor(eventBus: IExecutionEventBus) {
+    constructor(eventBus: ExecutionEventBus) {
         this.eventBus = eventBus;
         this.eventBus.on('event', this.handleEvent);
         this.eventBus.on('finished', this.handleFinished);

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -113,7 +113,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
                 id: requestContext.task?.id || uuidv4(), // Use existing task ID or generate new
                 contextId: finalMessageForAgent.contextId!,
                 status: {
-                    state: TaskState.Failed,
+                    state: "failed",
                     message: {
                         kind: "message",
                         role: "agent",
@@ -197,7 +197,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
                 taskId: requestContext.task?.id || uuidv4(), // Use existing or a placeholder
                 contextId: finalMessageForAgent.contextId!,
                 status: {
-                    state: TaskState.Failed,
+                    state: "failed",
                     message: {
                         kind: "message",
                         role: "agent",
@@ -247,12 +247,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         }
 
         // Check if task is in a cancelable state
-        const nonCancelableStates = [
-            TaskState.Completed,
-            TaskState.Failed,
-            TaskState.Canceled,
-            TaskState.Rejected,
-        ];
+        const nonCancelableStates = ["completed", "failed", "canceled", "rejected"];
         if (nonCancelableStates.includes(task.status.state)) {
             throw A2AError.taskNotCancelable(params.id);
         }
@@ -265,7 +260,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         else {
             // Here we are marking task as cancelled. We are not waiting for the executor to actually cancel processing.
             task.status = {
-                state: TaskState.Canceled,
+                state: "canceled",
                 message: { // Optional: Add a system message indicating cancellation
                     kind: "message",
                     role: "agent",
@@ -341,10 +336,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         yield task;
 
         // If task is already in a final state, no more events will come.
-        const finalStates = [
-            TaskState.Completed, TaskState.Failed,
-            TaskState.Canceled, TaskState.Rejected
-        ];
+        const finalStates = ["completed", "failed", "canceled", "rejected"];
         if (finalStates.includes(task.status.state)) {
             return;
         }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -4,7 +4,7 @@ import { Message, AgentCard, PushNotificationConfig, Task, MessageSendParams, Ta
 import { AgentExecutor } from "../agent_execution/agent_executor.js";
 import { RequestContext } from "../agent_execution/request_context.js";
 import { A2AError } from "../error.js";
-import { ExecutionEventBusManager, IExecutionEventBusManager } from "../events/execution_event_bus_manager.js";
+import { ExecutionEventBusManager, DefaultExecutionEventBusManager } from "../events/execution_event_bus_manager.js";
 import { ExecutionEventQueue } from "../events/execution_event_queue.js";
 import { ResultManager } from "../result_manager.js";
 import { TaskStore } from "../store.js";
@@ -14,7 +14,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     private readonly agentCard: AgentCard;
     private readonly taskStore: TaskStore;
     private readonly agentExecutor: AgentExecutor;
-    private readonly eventBusManager: IExecutionEventBusManager;
+    private readonly eventBusManager: ExecutionEventBusManager;
     // Store for push notification configurations (could be part of TaskStore or separate)
     private readonly pushNotificationConfigs: Map<string, PushNotificationConfig> = new Map();
 
@@ -23,7 +23,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         agentCard: AgentCard,
         taskStore: TaskStore,
         agentExecutor: AgentExecutor,
-        eventBusManager: IExecutionEventBusManager = new ExecutionEventBusManager(),
+        eventBusManager: ExecutionEventBusManager = new DefaultExecutionEventBusManager(),
     ) {
         this.agentCard = agentCard;
         this.taskStore = taskStore;

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,22 @@ export type SecurityScheme =
  */
 export type CancelTaskResponse = JSONRPCErrorResponse | CancelTaskSuccessResponse;
 /**
+ * Represents the possible states of a Task.
+ *
+ * This interface was referenced by `MySchema`'s JSON-Schema
+ * via the `definition` "TaskState".
+ */
+export type TaskState =
+  | "submitted"
+  | "working"
+  | "input-required"
+  | "completed"
+  | "canceled"
+  | "failed"
+  | "rejected"
+  | "auth-required"
+  | "unknown";
+/**
  * JSON-RPC response for the 'tasks/pushNotificationConfig/set' method.
  *
  * This interface was referenced by `MySchema`'s JSON-Schema
@@ -2080,22 +2096,4 @@ export interface TaskStatus2 {
    * ISO 8601 datetime string when the status was recorded.
    */
   timestamp?: string;
-}
-
-/**
- * Represents the possible states of a Task.
- *
- * This interface was referenced by `MySchema`'s JSON-Schema
- * via the `definition` "TaskState".
- */
-export enum TaskState {
-  Submitted = "submitted",
-  Working = "working",
-  InputRequired = "input-required",
-  Completed = "completed",
-  Canceled = "canceled",
-  Failed = "failed",
-  Rejected = "rejected",
-  AuthRequired = "auth-required",
-  Unknown = "unknown"
 }

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -26,13 +26,13 @@ class CancellableMockAgentExecutor implements AgentExecutor {
         const taskId = requestContext.taskId;
         const contextId = requestContext.contextId;
         
-        eventBus.publish({ id: taskId, contextId, status: { state: TaskState.Submitted }, kind: 'task' });
-        eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Working }, final: false });
+        eventBus.publish({ id: taskId, contextId, status: { state: "submitted" }, kind: 'task' });
+        eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: "working" }, final: false });
         
         // Simulate a long-running process
         for (let i = 0; i < 5; i++) {
             if (this.cancelledTasks.has(taskId)) {
-                eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Canceled }, final: true });
+                eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: "canceled" }, final: true });
                 eventBus.finished();
                 return;
             }
@@ -40,7 +40,7 @@ class CancellableMockAgentExecutor implements AgentExecutor {
             await this.clock.tickAsync(100); 
         }
 
-        eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Completed }, final: true });
+        eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: "completed" }, final: true });
         eventBus.finished();
     };
     
@@ -168,14 +168,14 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
             bus.publish({
                 id: taskId,
                 contextId,
-                status: { state: TaskState.Submitted },
+                status: { state: "submitted" },
                 kind: 'task'
             });
             bus.publish({
                 taskId,
                 contextId,
                 kind: 'status-update',
-                status: { state: TaskState.Working },
+                status: { state: "working" },
                 final: false
             });
             bus.publish({
@@ -188,7 +188,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
                 taskId,
                 contextId,
                 kind: 'status-update',
-                status: { state: TaskState.Completed, message: { role: 'agent', parts: [{kind: 'text', text: 'Done!'}], messageId: 'agent-msg-2', kind: 'message'} },
+                status: { state: "completed", message: { role: 'agent', parts: [{kind: 'text', text: 'Done!'}], messageId: 'agent-msg-2', kind: 'message'} },
                 final: true
             });
             bus.finished();
@@ -199,7 +199,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
         assert.equal(taskResult.kind, 'task');
         assert.equal(taskResult.id, taskId);
-        assert.equal(taskResult.status.state, TaskState.Completed);
+        assert.equal(taskResult.status.state, "completed");
         assert.isDefined(taskResult.artifacts, 'Task result should have artifacts');
         assert.isArray(taskResult.artifacts);
         assert.lengthOf(taskResult.artifacts!, 1);
@@ -214,11 +214,11 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         const contextId = 'ctx-stream-1';
 
         (mockAgentExecutor as MockAgentExecutor).execute.callsFake(async (ctx, bus) => {
-            bus.publish({ id: taskId, contextId, status: { state: TaskState.Submitted }, kind: 'task' });
+            bus.publish({ id: taskId, contextId, status: { state: "submitted" }, kind: 'task' });
             await new Promise(res => setTimeout(res, 10));
-            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Working }, final: false });
+            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: "working" }, final: false });
             await new Promise(res => setTimeout(res, 10));
-            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Completed }, final: true });
+            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: "completed" }, final: true });
             bus.finished();
         });
         
@@ -229,9 +229,9 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         }
 
         assert.lengthOf(events, 3, "Stream should yield 3 events");
-        assert.equal((events[0] as Task).status.state, TaskState.Submitted);
-        assert.equal((events[1] as TaskStatusUpdateEvent).status.state, TaskState.Working);
-        assert.equal((events[2] as TaskStatusUpdateEvent).status.state, TaskState.Completed);
+        assert.equal((events[0] as Task).status.state, "submitted");
+        assert.equal((events[1] as TaskStatusUpdateEvent).status.state, "working");
+        assert.equal((events[2] as TaskStatusUpdateEvent).status.state, "completed");
         assert.isTrue((events[2] as TaskStatusUpdateEvent).final);
     });
 
@@ -243,8 +243,8 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         const contextId = 'ctx-input';
 
         (mockAgentExecutor as MockAgentExecutor).execute.callsFake(async (ctx, bus) => {
-            bus.publish({ id: taskId, contextId, status: { state: TaskState.Submitted }, kind: 'task' });
-            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.InputRequired }, final: true });
+            bus.publish({ id: taskId, contextId, status: { state: "submitted" }, kind: 'task' });
+            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: "input-required" }, final: true });
             bus.finished();
         });
         
@@ -256,7 +256,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
         assert.lengthOf(events, 2);
         const lastEvent = events[1] as TaskStatusUpdateEvent;
-        assert.equal(lastEvent.status.state, TaskState.InputRequired);
+        assert.equal(lastEvent.status.state, "input-required");
         assert.isTrue(lastEvent.final);
     });
 
@@ -274,10 +274,10 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
             taskId = ctx.taskId;
             contextId = ctx.contextId;
 
-            bus.publish({ id: taskId, contextId, status: { state: TaskState.Submitted }, kind: 'task' });
-            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Working }, final: false });
+            bus.publish({ id: taskId, contextId, status: { state: "submitted" }, kind: 'task' });
+            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: "working" }, final: false });
             await clock.tickAsync(100);
-            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: TaskState.Completed }, final: true });
+            bus.publish({ taskId, contextId, kind: 'status-update', status: { state: "completed" }, final: true });
             bus.finished();
         });
     
@@ -309,25 +309,25 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         await clock.runAllAsync();
         await Promise.all([p1, p2]);
 
-        assert.equal((results1[0] as TaskStatusUpdateEvent).status.state, TaskState.Submitted);
-        assert.equal((results1[1] as TaskStatusUpdateEvent).status.state, TaskState.Working);
-        assert.equal((results1[2] as TaskStatusUpdateEvent).status.state, TaskState.Completed);
+        assert.equal((results1[0] as TaskStatusUpdateEvent).status.state, "submitted");
+        assert.equal((results1[1] as TaskStatusUpdateEvent).status.state, "working");
+        assert.equal((results1[2] as TaskStatusUpdateEvent).status.state, "completed");
 
         // First event of resubscribe is always a task.
-        assert.equal((results2[0] as Task).status.state, TaskState.Working);
-        assert.equal((results2[1] as TaskStatusUpdateEvent).status.state, TaskState.Completed);
+        assert.equal((results2[0] as Task).status.state, "working");
+        assert.equal((results2[1] as TaskStatusUpdateEvent).status.state, "completed");
         
         assert.isTrue(saveSpy.calledThrice, 'TaskStore.save should be called 3 times');
         const lastSaveCall = saveSpy.lastCall.args[0];
         assert.equal(lastSaveCall.id, taskId);
-        assert.equal(lastSaveCall.status.state, TaskState.Completed);
+        assert.equal(lastSaveCall.status.state, "completed");
     });
     
     it('getTask: should return an existing task from the store', async () => {
         const fakeTask: Task = {
             id: 'task-exist',
             contextId: 'ctx-exist',
-            status: { state: TaskState.Working },
+            status: { state: "working" },
             kind: 'task',
             history: []
         };
@@ -339,7 +339,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
     it('set/getTaskPushNotificationConfig: should save and retrieve config', async () => {
         const taskId = 'task-push-config';
-        const fakeTask: Task = { id: taskId, contextId: 'ctx-push', status: { state: TaskState.Working }, kind: 'task' };
+        const fakeTask: Task = { id: taskId, contextId: 'ctx-push', status: { state: "working" }, kind: 'task' };
         await mockTaskStore.save(fakeTask);
     
         const pushConfig: PushNotificationConfig = {
@@ -394,20 +394,20 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         assert.isTrue(cancellableExecutor.cancelTaskSpy.calledOnceWith(taskId, sinon.match.any));
         
         const lastEvent = streamEvents[streamEvents.length - 1] as TaskStatusUpdateEvent;
-        assert.equal(lastEvent.status.state, TaskState.Canceled);
+        assert.equal(lastEvent.status.state, "canceled");
         
         const finalTask = await handler.getTask({ id: taskId });
-        assert.equal(finalTask.status.state, TaskState.Canceled);
+        assert.equal(finalTask.status.state, "canceled");
 
         // Canceled API issues cancel request to executor and returns latest task state.
         // In this scenario, executor is waiting on clock to detect that task has been cancelled.
         // While the cancel API has returned with latest task state => Working.
-        assert.equal(cancelResponse.status.state, TaskState.Working);
+        assert.equal(cancelResponse.status.state, "working");
     });
 
     it('cancelTask: should fail for tasks in a terminal state', async () => {
         const taskId = 'task-terminal';
-        const fakeTask: Task = { id: taskId, contextId: 'ctx-terminal', status: { state: TaskState.Completed }, kind: 'task' };
+        const fakeTask: Task = { id: taskId, contextId: 'ctx-terminal', status: { state: "completed" }, kind: 'task' };
         await mockTaskStore.save(fakeTask);
 
         try {

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -4,8 +4,8 @@ import sinon, { SinonStub, SinonFakeTimers } from 'sinon';
 
 import { AgentExecutor } from '../../src/server/agent_execution/agent_executor.js';
 import { describe, beforeEach, afterEach, it } from 'node:test';
-import { RequestContext, IExecutionEventBus, TaskStore, InMemoryTaskStore, DefaultRequestHandler, AgentCard, Artifact, Message, MessageSendParams, PushNotificationConfig, Task, TaskIdParams, TaskPushNotificationConfig, TaskState, TaskStatusUpdateEvent } from '../../src/index.js';
-import { ExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
+import { RequestContext, ExecutionEventBus, TaskStore, InMemoryTaskStore, DefaultRequestHandler, AgentCard, Artifact, Message, MessageSendParams, PushNotificationConfig, Task, TaskIdParams, TaskPushNotificationConfig, TaskState, TaskStatusUpdateEvent } from '../../src/index.js';
+import { DefaultExecutionEventBusManager, ExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
 import { A2ARequestHandler } from '../../src/server/request_handler/a2a_request_handler.js';
 
 /**
@@ -21,7 +21,7 @@ class CancellableMockAgentExecutor implements AgentExecutor {
 
     public execute = async (
         requestContext: RequestContext,
-        eventBus: IExecutionEventBus,
+        eventBus: ExecutionEventBus,
     ): Promise<void> => {
         const taskId = requestContext.taskId;
         const contextId = requestContext.contextId;
@@ -46,7 +46,7 @@ class CancellableMockAgentExecutor implements AgentExecutor {
     
     public cancelTask = async (
         taskId: string,
-        eventBus: IExecutionEventBus,
+        eventBus: ExecutionEventBus,
     ): Promise<void> => {
         this.cancelledTasks.add(taskId);
         // The execute loop is responsible for publishing the final state
@@ -89,7 +89,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         mockTaskStore = new InMemoryTaskStore();
         // Default mock for most tests
         mockAgentExecutor = new MockAgentExecutor();
-        executionEventBusManager = new ExecutionEventBusManager();
+        executionEventBusManager = new DefaultExecutionEventBusManager();
         handler = new DefaultRequestHandler(
             testAgentCard,
             mockTaskStore,
@@ -120,10 +120,10 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     class MockAgentExecutor implements AgentExecutor {
         // Stubs to control and inspect calls to execute and cancelTask
         public execute: SinonStub<
-            [RequestContext, IExecutionEventBus],
+            [RequestContext, ExecutionEventBus],
             Promise<void>
         > = sinon.stub();
-        public cancelTask: SinonStub<[string, IExecutionEventBus], Promise<void>> =
+        public cancelTask: SinonStub<[string, ExecutionEventBus], Promise<void>> =
             sinon.stub();
     }
 


### PR DESCRIPTION
Typescript reviewers suggested: TypeScript enums are an anti-pattern -- prefer string literal unions (e.g. "foo" | "bar"). all the same autocomplete niceties but doesn't create non-erasable syntax