### PR TITLE
fix: remove console log

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -75,7 +75,6 @@ export class A2AClient {
         throw new Error("Fetched Agent Card does not contain a valid 'url' for the service endpoint.");
       }
       this.serviceEndpointUrl = agentCard.url; // Cache the service endpoint URL from the agent card
-      console.log("ENDOPINT", this.serviceEndpointUrl);
       return agentCard;
     } catch (error) {
       console.error("Error fetching or parsing Agent Card:");


### PR DESCRIPTION
# Description

Removes `console.log` from A2AClient fetch agent card.
