### PR TITLE
feat: Added the Eliza chatbot to demo support for user/business/gov scoped agent identities and universal authentication (DIDs, JWT, and the Agentic Profile)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@a2a-js/sdk",
       "version": "0.2.1",
       "dependencies": {
+        "@agentic-profile/auth": "^0.6.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.1",
         "body-parser": "^2.2.0",
@@ -16,6 +17,7 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
+        "@agentic-profile/eliza": "^0.1.0",
         "@genkit-ai/googleai": "^1.8.0",
         "@genkit-ai/vertexai": "^1.8.0",
         "@types/chai": "^5.2.2",
@@ -35,6 +37,35 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@agentic-profile/auth": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@agentic-profile/auth/-/auth-0.6.0.tgz",
+      "integrity": "sha512-BwuaBfo+CA1g0JrcWmZW1Ek2nh8vV6J+kNX5kXbd0dH546ekqXg79NBiu6TDN0Ixb2H+5rhPv+kd/fwdpvovow==",
+      "license": "Apache-2",
+      "dependencies": {
+        "@agentic-profile/common": "^0.6.0",
+        "@noble/ed25519": "^2.2.3",
+        "did-resolver": "^4.1.0",
+        "loglevel": "^1.9.2"
+      }
+    },
+    "node_modules/@agentic-profile/common": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@agentic-profile/common/-/common-0.6.0.tgz",
+      "integrity": "sha512-rSykQakmrXPRsI4jOERVWF10J7brL9o+KyTRAwQbVEH7z20zEUfqINxaThz9YtBGzdMCvnFiY8aYmxX6+JIIiw==",
+      "license": "Apache-2",
+      "dependencies": {
+        "did-resolver": "^4.1.0",
+        "loglevel": "^1.9.2"
+      }
+    },
+    "node_modules/@agentic-profile/eliza": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@agentic-profile/eliza/-/eliza-0.1.0.tgz",
+      "integrity": "sha512-xMn78klrEslvNMFY3xNQCzol1xdO+MxYJ9UBUSDxIBTM+Xmd6a5/t0ioIhZzNp4qYlPguy+qNSMZYwhm7NYrfQ==",
+      "dev": true,
+      "license": "Apache-2"
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.24.3",
@@ -1544,6 +1575,15 @@
       },
       "peerDependencies": {
         "zod": ">= 3"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4129,6 +4169,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/did-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
+      "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==",
+      "license": "Apache-2.0"
     },
     "node_modules/diff": {
       "version": "7.0.0",
@@ -6805,6 +6851,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@agentic-profile/eliza": "^0.1.0",
     "@genkit-ai/googleai": "^1.8.0",
     "@genkit-ai/vertexai": "^1.8.0",
     "@types/chai": "^5.2.2",
@@ -39,9 +40,12 @@
     "coverage": "c8 npm run test",
     "generate": "curl https://raw.githubusercontent.com/google-a2a/A2A/refs/heads/main/specification/json/a2a.json > spec.json && node scripts/generateTypes.js && rm spec.json",
     "sample:cli": "tsx src/samples/cli.ts",
-    "sample:movie-agent": "tsx src/samples/agents/movie-agent/index.ts"
+    "sample:movie-agent": "tsx src/samples/agents/movie-agent/index.ts",
+    "agent:eliza": "tsx src/samples/agents/eliza/eliza-app.ts",
+    "create-demo-agentic-profile": "tsx scripts/create-global-agentic-profile.ts"
   },
   "dependencies": {
+    "@agentic-profile/auth": "^0.6.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "body-parser": "^2.2.0",

--- a/scripts/create-global-agentic-profile.ts
+++ b/scripts/create-global-agentic-profile.ts
@@ -1,0 +1,54 @@
+import os from "os";
+import { join } from "path";
+import {
+    createAgenticProfile,
+    prettyJson,
+    webDidToUrl
+} from "@agentic-profile/common";
+import {
+    createEdDsaJwk,
+    postJson
+} from "@agentic-profile/auth";
+import { saveProfile } from "../src/samples/universal-auth.js";
+
+
+(async ()=>{
+    const port = process.env.PORT || 4004;
+    const services = [
+        {
+            name: "Business networking connector",
+            type: "A2A",
+            id: "connect",
+            url: `httsp://example.com/agents/connect`
+        }
+    ];
+    const { profile, keyring, b64uPublicKey } = await createAgenticProfile({ services, createJwkSet: createEdDsaJwk });
+
+    try {
+        // publish profile to web (so did:web:... will resolve)
+        const { data } = await postJson(
+            "https://testing.agenticprofile.ai/agentic-profile",
+            { profile, b64uPublicKey }
+        );
+        const savedProfile = data.profile;
+        const did = savedProfile.id;
+        console.log( `Published demo user agentic profile to:
+
+    ${webDidToUrl(did)}
+
+Or via DID at:
+
+    ${did}
+`);
+
+        // also save locally for reference
+        const dir = join( os.homedir(), ".agentic", "iam", "a2a-demo-user" );
+        await saveProfile({ dir, profile: savedProfile, keyring });
+
+        console.log(`Saved demo user agentic profile to ${dir}
+
+Shhhh! Keyring for testing... ${prettyJson( keyring )}`);
+    } catch (error) {
+        console.error( "Failed to create demo user profile", error );
+    }
+})();

--- a/src/client/auth-handler.ts
+++ b/src/client/auth-handler.ts
@@ -1,0 +1,29 @@
+export interface HttpHeaders { [key: string]: string };
+
+/**
+ * Handle HTTP 401 and 403 error codes from fetch results. If the shouldRetryWithHeaders
+ * function returns revised headers, then retry the request using revised headers and report
+ * success with onSuccess().
+ */
+export interface AuthenticationHandler {
+    /**
+     * Provides additional HTTP request headers.
+     * @returns HTTP headers which should include Authorization.
+     */
+    headers: () => HttpHeaders;
+
+    /**
+     * Called to check if the HTTP request should be retried with new headers.  This usually
+     * occours when the HTTP response issues a 401 or 403.  If this
+     * function returns new HTTP headers, then the request should be retried with
+     * the revised headers.
+     * @param req The RequestInit object used to invoke fetch()
+     * @param res The fetch Response object
+     * @returns If the HTTP request should be retried then returns the HTTP headers to use,
+     * 	or returns undefined if no retry should be made.
+     */
+    shouldRetryWithHeaders: (req:RequestInit, res:Response) => Promise<HttpHeaders | undefined>;
+
+    /* If the last call using the headers was successful, report back using this function. */
+    onSuccess: (headers:HttpHeaders) => Promise<void>
+}

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -31,9 +31,14 @@ import {
   A2AError,
   SendMessageSuccessResponse
 } from '../types.js'; // Assuming schema.ts is in the same directory or appropriately pathed
+import { AuthenticationHandler, HttpHeaders } from './auth-handler.js';
 
 // Helper type for the data yielded by streaming methods
 type A2AStreamEventData = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
+
+export interface A2AClientOptions {
+  authHandler?: AuthenticationHandler
+}
 
 /**
  * A2AClient is a TypeScript HTTP client for interacting with A2A-compliant agents.
@@ -43,6 +48,7 @@ export class A2AClient {
   private agentCardPromise: Promise<AgentCard>;
   private requestIdCounter: number = 1;
   private serviceEndpointUrl?: string; // To be populated from AgentCard after fetching
+  private authHandler?: AuthenticationHandler;
 
   /**
    * Constructs an A2AClient instance.
@@ -51,9 +57,10 @@ export class A2AClient {
    * The `url` field from the Agent Card will be used as the RPC service endpoint.
    * @param agentBaseUrl The base URL of the A2A agent (e.g., https://agent.example.com).
    */
-  constructor(agentBaseUrl: string) {
+  constructor(agentBaseUrl: string, options?: A2AClientOptions) {
     this.agentBaseUrl = agentBaseUrl.replace(/\/$/, ""); // Remove trailing slash if any
     this.agentCardPromise = this._fetchAndCacheAgentCard();
+    this.authHandler = options?.authHandler;
   }
 
   /**
@@ -62,7 +69,7 @@ export class A2AClient {
    * @returns A Promise that resolves to the AgentCard.
    */
   private async _fetchAndCacheAgentCard(): Promise<AgentCard> {
-    const agentCardUrl = `${this.agentBaseUrl}/.well-known/agent.json`;
+    const agentCardUrl = this.resolveAgentCardUrl( this.agentBaseUrl );
     try {
       const response = await fetch(agentCardUrl, {
         headers: { 'Accept': 'application/json' },
@@ -75,7 +82,7 @@ export class A2AClient {
         throw new Error("Fetched Agent Card does not contain a valid 'url' for the service endpoint.");
       }
       this.serviceEndpointUrl = agentCard.url; // Cache the service endpoint URL from the agent card
-      console.log("ENDOPINT", this.serviceEndpointUrl);
+      console.log("ENDPOINT", this.serviceEndpointUrl);
       return agentCard;
     } catch (error) {
       console.error("Error fetching or parsing Agent Card:");
@@ -94,8 +101,8 @@ export class A2AClient {
    */
   public async getAgentCard(agentBaseUrl?: string): Promise<AgentCard> {
     if (agentBaseUrl) {
-      const specificAgentBaseUrl = agentBaseUrl.replace(/\/$/, "");
-      const agentCardUrl = `${specificAgentBaseUrl}/.well-known/agent.json`;
+      const agentCardUrl = this.resolveAgentCardUrl( agentBaseUrl );
+      
       const response = await fetch(agentCardUrl, {
         headers: { 'Accept': 'application/json' },
       });
@@ -106,6 +113,21 @@ export class A2AClient {
     }
     // If no specific URL is given, return the promise for the initially configured agent's card.
     return this.agentCardPromise;
+  }
+
+  /**
+   * Determines the agent card URL based on the agent URL.  If the agent URL is at the root
+   * of a webserver, then the well-known agent card path will be used.  Otherwise /agent.json
+   * will be appended to the URL path.
+   * @param agentUrl The agent URL.
+   * @returns The agent card URL.
+   */
+  private resolveAgentCardUrl( agentUrl: string ): string {
+    agentUrl = agentUrl.replace(/\/$/, ""); // remove trailing slash if any
+    const url = new URL( agentUrl );
+    return url.pathname === "/"
+      ? `${agentUrl}/.well-known/agent.json`
+      : `${agentUrl}/agent.json`;
   }
 
   /**
@@ -145,14 +167,7 @@ export class A2AClient {
       id: requestId,
     };
 
-    const httpResponse = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Accept": "application/json", // Expect JSON response for non-streaming requests
-      },
-      body: JSON.stringify(rpcRequest),
-    });
+    const httpResponse = await this._fetch( endpoint, rpcRequest );
 
     if (!httpResponse.ok) {
       let errorBodyText = '(empty or non-JSON response)';
@@ -186,6 +201,39 @@ export class A2AClient {
     return rpcResponse as TResponse;
   }
 
+  /**
+   * fetch() with authentication handling.  Uses a generic authentication handler that can inspect
+   * HTTP response codes and headers and suggest new headers to use during an automatic retry.
+   * @param url The URL to fetch.
+   * @param rpcRequest The JSON-RPC request to send.
+   * @param acceptHeader The Accept header to use.  Defaults to "application/json".
+   * @returns A Promise that resolves to the fetch HTTP response.
+   */
+  private async _fetch( url: string, rpcRequest: JSONRPCRequest, acceptHeader: string = "application/json" ): Promise<Response> {
+    const options = (headers: HttpHeaders = {}) => ({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": acceptHeader, // Expect JSON response for non-streaming requests
+        ...headers // if we have an Authorization header, add it
+      },
+      body: JSON.stringify(rpcRequest)
+    } as RequestInit);
+    const requestInit = options( this.authHandler?.headers() );
+
+    let fetchResponse = await fetch(url, requestInit);
+
+    // check for HTTP 401/403 and retry request if necessary
+    const updatedHeaders = await this.authHandler?.shouldRetryWithHeaders(requestInit, fetchResponse);
+    if (updatedHeaders) {
+      // retry request with revised headers
+      fetchResponse = await fetch(url, options(updatedHeaders));
+      if (fetchResponse.ok && this.authHandler?.onSuccess)
+        await this.authHandler.onSuccess(updatedHeaders); // Remember headers that worked
+    }
+
+    return fetchResponse;
+  }
 
   /**
    * Sends a message to the agent.
@@ -223,14 +271,7 @@ export class A2AClient {
       id: clientRequestId,
     };
 
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Accept": "text/event-stream", // Crucial for SSE
-      },
-      body: JSON.stringify(rpcRequest),
-    });
+    const response = await this._fetch( endpoint, rpcRequest, "text/event-stream" );
 
     if (!response.ok) {
       // Attempt to read error body for more details

--- a/src/samples/agents/eliza/README.md
+++ b/src/samples/agents/eliza/README.md
@@ -1,0 +1,55 @@
+# Eliza Agent
+
+This agent uses the Eliza chatbot to provide Rogerian psychotherapy. To run:
+
+    ```bash
+    npm run agent:eliza
+    ```
+
+The agent server will start on `http://localhost:41241` and provides agent.json cards at three endpoints which are listed by the server.
+
+
+## Chat with Eliza without Universal Authentication
+
+The Eliza agent provides a well-known endpoint that does not require authentication.
+
+1. Make sure Eliza is running:
+
+    ```bash
+    npm run agent:eliza
+    ```
+
+2. In a separate terminal window, use the command line interface to connect:
+
+    ```bash
+    npm run sample:cli http://localhost:41241
+    ```
+
+
+## Chat with Eliza WITH Universal Authentication
+
+Universal Authentication uses W3C Decentralized IDs (DIDs) and DID documents to scope agents to people, businesses, and governments.  Each DID document contains the cryptographic public keys which allow agents to authenticate without centralized authentication servers.
+
+The Eliza agent provides the /agents/eliza endpoint that requires authentication.
+
+1. Make sure you have created a demo agentic profile
+
+    ```bash
+    npm run create-demo-agentic-profile
+    ```
+
+2. Make sure Eliza is running:
+
+    ```bash
+    npm run agent:eliza
+    ```
+
+3. In a separate terminal window, use the command line interface to connect:
+
+    ```bash
+    npm run sample:cli http://localhost:41241 #connect
+    ```
+
+    Type in a message to the Eliza agent to cause an A2A RPC call to the server which triggers the authentication.
+
+To read more about Universal Authentication and DIDs can be used with A2A please visit the [AgenticProfile blog](https://agenticprofile.ai)

--- a/src/samples/agents/eliza/eliza-agent-card.ts
+++ b/src/samples/agents/eliza/eliza-agent-card.ts
@@ -1,0 +1,42 @@
+import { AgentCard } from "../../../index.js";
+
+
+
+export const elizaAgentCard = ( url?: string ): AgentCard => ({
+    name: 'Eliza Agent',
+    description: 'The classic AI chatbot from 1966 - simulates Rogerian psychotherapy',
+    // Adjust the base URL and port as needed. /a2a is the default base in A2AExpressApp
+    url, 
+    provider: {
+      organization: 'A2A Samples',
+      url: 'https://example.com/a2a-samples' // Added provider URL
+    },
+    version: '0.0.1', // Incremented version
+    capabilities: {
+      streaming: true, // The new framework supports streaming
+      pushNotifications: false, // Assuming not implemented for this agent yet
+      stateTransitionHistory: true, // Agent uses history
+    },
+    // authentication: null, // Property 'authentication' does not exist on type 'AgentCard'.
+    securitySchemes: undefined, // Or define actual security schemes if any
+    security: undefined,
+    defaultInputModes: ['text'],
+    defaultOutputModes: ['text', 'task-status'], // task-status is a common output mode
+    skills: [
+      {
+        id: 'therapy',
+        name: 'Rogerian Psychotherapy',
+        description: 'Provides Rogerian psychotherapy',
+        tags: ['health', 'wellness', 'therapy'],
+        examples: [
+          'I feel like I am not good enough',
+          'I am not sure what to do',
+          'I am feeling overwhelmed',
+          'I am not sure what to do'
+        ],
+        inputModes: ['text'], // Explicitly defining for skill
+        outputModes: ['text', 'task-status'] // Explicitly defining for skill
+      },
+    ],
+    supportsAuthenticatedExtendedCard: false,
+  });

--- a/src/samples/agents/eliza/eliza-agent.ts
+++ b/src/samples/agents/eliza/eliza-agent.ts
@@ -1,0 +1,105 @@
+import { v4 as uuidv4 } from 'uuid'; // For generating unique IDs
+import { ElizaBot } from "@agentic-profile/eliza";
+import { ClientAgentSession } from '@agentic-profile/auth';
+
+import {
+    AgentExecutor,
+    RequestContext,
+    ExecutionEventBus,
+    TaskStatusUpdateEvent,
+    TextPart,
+    Message
+} from "../../../index.js";
+import { SessionContextStore } from "./store.js";
+
+/**
+ * ElizaAgentExecutor implements the Eliza DOCTOR agent.
+ */
+export class ElizaAgentExecutor implements AgentExecutor {
+    private sessionContextStore: SessionContextStore;
+
+    constructor( sessionContextStore: SessionContextStore ) {
+        this.sessionContextStore = sessionContextStore;
+    }
+
+    public cancelTask = async (
+        _taskId: string,
+        _eventBus: ExecutionEventBus,
+    ): Promise<void> => {
+        console.log( `[ElizaAgentExecutor] Does not support Cancelling tasks` );
+    };
+
+    async execute(
+        requestContext: RequestContext,
+        eventBus: ExecutionEventBus
+    ): Promise<void> {
+        const userMessage = requestContext.userMessage;
+        const taskId = requestContext.taskId;
+        const contextId = requestContext.contextId;
+        const sessionId = getSessionId( requestContext );
+        console.log(
+            `[ElizaAgentExecutor] Processing message ${userMessage.messageId} for task ${taskId} context ${contextId} in session ${sessionId ?? "- none -"}`
+        );
+
+        try {
+            const userText = userMessage.parts
+                .filter((p) => p.kind === 'text' && !!p.text)
+                .map(p => (p as TextPart).text)
+                .join('. ');
+
+            const eliza = new ElizaBot(false);
+            const elizaState = await this.sessionContextStore.loadContext( sessionId, contextId );
+            if( elizaState )
+                eliza.setState( elizaState );
+        
+            const agentReplyText = userText ? eliza.transform( userText )!: eliza.getInitial()!;
+        
+            await this.sessionContextStore.saveContext( sessionId, contextId, eliza.getState() );
+
+            // 5. Publish final task status update
+            const agentMessage: Message = {
+                kind: 'message',
+                role: 'agent',
+                messageId: uuidv4(),
+                parts: [{ kind: 'text', text: agentReplyText }], // Ensure some text
+                taskId: undefined, // Don't pass taskId to client, otherwise it will be passed back to the server in the next request
+                contextId: contextId,
+            };
+            eventBus.publish(agentMessage);
+
+            console.log(
+                `[ElizaAgentExecutor] Context ${contextId} finished`
+            );
+
+        } catch (error: any) {
+            console.error(
+            `[ElizaAgentExecutor] Error processing task ${taskId}:`,
+            error
+            );
+            const errorUpdate: TaskStatusUpdateEvent = {
+                kind: 'status-update',
+                taskId: taskId,
+                contextId: contextId,
+                status: {
+                    state: 'failed',
+                    message: {
+                        kind: 'message',
+                        role: 'agent',
+                        messageId: uuidv4(),
+                        parts: [{ kind: 'text', text: `Agent error: ${error.message}` }],
+                        taskId: taskId,
+                        contextId: contextId,
+                    },
+                    timestamp: new Date().toISOString(),
+                },
+                final: true,
+            };
+            eventBus.publish(errorUpdate);
+        }
+    }
+}
+
+function getSessionId( requestContext: RequestContext ): string {
+    const session = (requestContext as any)?.session as ClientAgentSession;
+    return session?.agentDid ?? "";
+}

--- a/src/samples/agents/eliza/eliza-app.ts
+++ b/src/samples/agents/eliza/eliza-app.ts
@@ -1,0 +1,63 @@
+import { createDidResolver } from "@agentic-profile/common";
+import { Request, Response } from "express";
+
+import { InMemoryTaskStore, TaskStore } from "../../../index.js";
+import { AgentExecutor } from "../../../index.js";
+import { DefaultRequestHandler } from "../../../index.js";
+import { A2AExpressService, resolveAgentSession } from "../../../server/a2a_express_service.js";
+import express from "express";
+import { elizaAgentCard } from "./eliza-agent-card.js";
+import { ElizaAgentExecutor } from "./eliza-agent.js";
+
+import { InMemoryUnifiedStore } from "./store.js";
+const unifiedStore = new InMemoryUnifiedStore();
+
+async function main() {
+    const PORT = process.env.PORT || 41241;
+
+    // 1. Prepare TaskStore and AgentExecutor
+    const taskStore: TaskStore = new InMemoryTaskStore();
+    const agentExecutor: AgentExecutor = new ElizaAgentExecutor( unifiedStore );
+  
+    // 2. Create DefaultRequestHandler.  This can be used by both the well-known and authenticated agents.
+    const agentCard = elizaAgentCard();
+    const requestHandler = new DefaultRequestHandler(
+        agentCard,
+        taskStore,
+        agentExecutor
+    );
+  
+    // 3. Create and setup A2A app
+    const app = express();
+    app.use(express.json());
+
+    // 4. Create a "well-known" Eliza with no authentication
+    const openAgentPath = "/";
+    const wellKnownService = new A2AExpressService( requestHandler, { agentPath: openAgentPath } );
+    app.use(openAgentPath, wellKnownService.routes());
+    const wellKnownCardPath = "/.well-known/agent.json";
+    app.get(wellKnownCardPath, wellKnownService.cardEndpoint );
+
+    // 5. Prepare to resolve DIDs and agent sessions for universal authentication
+    const didResolver = createDidResolver();
+    const agentSessionResolver = async ( req: Request, res: Response ) => {
+        return resolveAgentSession( req, res, unifiedStore, didResolver );
+    }
+
+    // 6. Create an Eliza at "/agents/eliza" that requires authentication
+    const a2aServiceWithAuth = new A2AExpressService( requestHandler, { agentSessionResolver } );
+    const secureAgentPath = "/agents/eliza";
+    app.use(secureAgentPath, a2aServiceWithAuth.routes());
+  
+    // 7. Start the server
+    const baseUrl = `http://localhost:${PORT}`;
+    app.listen(PORT, () => {
+        console.log(`[ElizaAgent] Server using new framework started on ${baseUrl}`);
+        console.log(`[ElizaAgent]   Open Agent Card: ${baseUrl}${wellKnownCardPath}`);
+        console.log(`[ElizaAgent]   Open Agent Card: ${baseUrl}${openAgentPath}agent.json`);
+        console.log(`[ElizaAgent] Secure Agent Card: ${baseUrl}${secureAgentPath}/agent.json`);
+        console.log('[ElizaAgent] Press Ctrl+C to stop the server');
+    });
+}
+  
+main().catch(console.error);

--- a/src/samples/agents/eliza/store.ts
+++ b/src/samples/agents/eliza/store.ts
@@ -1,0 +1,44 @@
+import {
+    ClientAgentSession,
+    ClientAgentSessionStore,
+    ClientAgentSessionUpdates
+} from "@agentic-profile/auth";
+
+export interface SessionContextStore {
+    saveContext( sessionId: string, contextId: string, context: unknown ): Promise<void>;
+    loadContext( sessionId: string, contextId: string ): Promise<unknown>;
+}
+
+export class InMemoryUnifiedStore implements ClientAgentSessionStore, SessionContextStore {
+    private nextSessionId = 1;
+    private clientSessions = new Map<number,ClientAgentSession>();
+    private contextStore = new Map<string, unknown>();
+
+    // ClientAgentSessionStore methods
+    async createClientAgentSession( challenge: string ) {
+        const id = this.nextSessionId++;
+        this.clientSessions.set( id, { id, challenge, created: new Date() } as ClientAgentSession );
+        return id;
+    }
+
+    async fetchClientAgentSession( id:number ) {
+        return this.clientSessions.get( id );  
+    }
+
+    async updateClientAgentSession( id:number, updates:ClientAgentSessionUpdates ) {
+        const session = this.clientSessions.get( id );
+        if( !session )
+            throw new Error("Failed to find client session by id: " + id );
+        else
+            this.clientSessions.set( id, { ...session, ...updates } );
+    }
+
+    // SessionContextStore methods
+    async saveContext( sessionId: string, contextId: string, context: unknown ): Promise<void> {
+        this.contextStore.set( `${sessionId}:${contextId}`, context );
+    }
+
+    async loadContext( sessionId: string, contextId: string ): Promise<unknown> {
+        return this.contextStore.get( `${sessionId}:${contextId}` );
+    }
+}

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -19,6 +19,7 @@ import {
   Part, // Added for explicit Part typing
   A2AClient,
 } from "../index.js";
+import { createAuthHandler } from "./universal-auth.js";
 
 // --- ANSI Colors ---
 const colors = {
@@ -47,7 +48,12 @@ function generateId(): string { // Renamed for more general use
 let currentTaskId: string | undefined = undefined; // Initialize as undefined
 let currentContextId: string | undefined = undefined; // Initialize as undefined
 const serverUrl = process.argv[2] || "http://localhost:41241"; // Agent's base URL
-const client = new A2AClient(serverUrl);
+
+// Use universal authentication?
+const userAgentDid = process.argv[3];
+const authProfile = process.argv[4] ?? "a2a-demo-user";
+
+let client: A2AClient; // Declare client variable
 let agentName = "Agent"; // Default, try to get from agent card later
 
 // --- Readline Setup ---
@@ -194,6 +200,10 @@ async function fetchAndDisplayAgentCard() {
 async function main() {
   console.log(colorize("bright", `A2A Terminal Client`));
   console.log(colorize("dim", `Agent Base URL: ${serverUrl}`));
+
+  // Initialize the client with proper authentication
+  const authHandler = userAgentDid ? await createAuthHandler(authProfile, userAgentDid) : undefined;
+  client = new A2AClient(serverUrl, { authHandler });
 
   await fetchAndDisplayAgentCard(); // Fetch the card before starting the loop
 

--- a/src/samples/universal-auth.ts
+++ b/src/samples/universal-auth.ts
@@ -1,0 +1,127 @@
+import { join } from "path";
+import os from "os";
+import { HttpHeaders } from "../client/auth-handler.js";
+import { generateAuthToken, parseChallengeFromWwwAuthenticate } from "@agentic-profile/auth";
+import { pruneFragmentId } from "@agentic-profile/common";
+
+import {
+    AgenticProfile,
+    JWKSet,
+} from "@agentic-profile/common/schema";
+import { prettyJson } from "@agentic-profile/common";
+
+import {
+    access,
+    mkdir,
+    readFile,
+    writeFile
+} from "fs/promises";
+
+
+export async function createAuthHandler( iamProfile: string = "my-a2a-client", userAgentDid: string ) {
+    const myProfileAndKeyring = await loadProfileAndKeyring( join( os.homedir(), ".agentic", "iam", iamProfile ) );
+    let headers = {} as HttpHeaders;
+
+    const { documentId, fragmentId } = pruneFragmentId( userAgentDid );
+    const agentDid = documentId ? userAgentDid : myProfileAndKeyring.profile.id + fragmentId;
+
+    const authHandler = {
+        headers: () => headers,
+        shouldRetryWithHeaders: async (req:RequestInit, fetchResponse:Response) => {
+            // can/should I handle this?
+            if( fetchResponse.status !== 401 )
+                return undefined;
+
+            const wwwAuthenticate = fetchResponse.headers.get( "WWW-Authenticate" );
+            const agenticChallenge = parseChallengeFromWwwAuthenticate( wwwAuthenticate, fetchResponse.url );
+
+            const authToken = await generateAuthToken({
+                agentDid,
+                agenticChallenge,
+                profileResolver: async (did:string) => {
+                    const { documentId } = pruneFragmentId( did );
+                    if( documentId !== myProfileAndKeyring.profile.id )
+                        throw new Error(`Failed to resolve agentic profile for ${did}`);
+                    return myProfileAndKeyring;
+                }
+            });
+            return { Authorization: `Agentic ${authToken}` };
+        },
+        onSuccess: async (updatedHeaders:HttpHeaders) => {
+            headers = updatedHeaders;
+        }
+    };
+
+    return authHandler;
+}
+
+/**
+ * Local file system utilities for loading and saving agentic profiles and keyrings.
+ */
+
+type SaveProfileParams = {
+    dir: string,
+    profile?: AgenticProfile,
+    keyring?: JWKSet[]
+}
+
+export async function saveProfile({ dir, profile, keyring }: SaveProfileParams) {
+    await mkdir(dir, { recursive: true });
+
+    const profilePath = join(dir, "did.json");
+    if( profile ) {
+        await writeFile(
+            profilePath,
+            prettyJson( profile ),
+            "utf8"
+        );
+    }
+
+    const keyringPath = join(dir, "keyring.json");
+    if( keyring ) {
+        await writeFile(
+            keyringPath,
+            prettyJson( keyring ),
+            "utf8"
+        );
+    }  
+
+    return { profilePath, keyringPath }
+}
+
+export async function loadProfileAndKeyring( dir: string ) {
+    const profile = await loadProfile( dir );
+    const keyring = await loadKeyring( dir );
+    return { profile, keyring };
+}
+
+export async function loadProfile( dir: string ) {
+    return loadJson<AgenticProfile>( dir, "did.json" );
+}
+
+export async function loadKeyring( dir: string ) {
+    return loadJson<JWKSet[]>( dir, "keyring.json" );
+}
+
+export async function loadJson<T>( dir: string, filename: string ): Promise<T> {
+    const path = join( dir, filename );
+    if( await fileExists( path ) !== true )
+        throw new Error(`Failed to load ${path} - file not found`);
+
+    const buffer = await readFile( path, "utf-8" );
+    return JSON.parse( buffer ) as T;
+}
+
+
+//
+// General util
+//
+
+async function fileExists(path: string): Promise<boolean> {
+    try {
+        await access(path);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}

--- a/src/server/a2a_express_service.ts
+++ b/src/server/a2a_express_service.ts
@@ -1,0 +1,195 @@
+/**
+ * A2AExpressService provides endpoints for an A2A service agent card and JSON-RPC requests.
+ * This class supports multiple A2A services on the same server, as well as support for
+ * universal authentication and agent multi-tenancy.
+ * 
+ * Agent multi-tenancy is the ability of one agent to represent multiple users.  For example, an
+ * (Eliza) therapist agent POST /message to the "Joseph" therapist would reply as Joseph, whereas the
+ * same agent POST /message to the "Sarah" therapist would reply as Sarah.
+ * 
+ * To see multi-tenancy in production, see [Matchwise](https://matchwise.ai) where the Connect agent represents
+ * many users to provide personalized business networking advice.
+ * 
+ * Universal authentication is the ability to authenticate any client without the need for 
+ * an authentication service like OAuth.  Universal authentication uses public key cryptography
+ * where the public keys for clients are distributed in W3C DID documents.
+ */
+
+import { Request, Response, Router } from 'express';
+import { Resolver } from "did-resolver";
+import {
+    b64u,
+    ClientAgentSession,
+    ClientAgentSessionStore,
+    createChallenge,
+    handleAuthorization,
+} from "@agentic-profile/auth";
+
+import { A2AError } from "./error.js";
+import { A2AResponse, JSONRPCErrorResponse, JSONRPCSuccessResponse } from "../index.js";
+import { A2ARequestHandler } from "./request_handler/a2a_request_handler.js";
+import { JsonRpcTransportHandler } from "./transports/jsonrpc_transport_handler.js";
+
+export type AgentSessionResolver = ( req: Request, res: Response ) => Promise<ClientAgentSession | null>
+
+/**
+ * Options for configuring the A2AService.
+ */
+export interface A2AServiceOptions {
+    /** Task storage implementation. Defaults to InMemoryTaskStore. */
+    //taskStore?: TaskStore;
+
+    /** URL Path for the A2A endpoint. If not provided, the req.originalUrl is used. */
+    agentPath?: string;
+
+    /** Agent session resolver. If not defined, then universal authentication is not supported. */
+    agentSessionResolver?: AgentSessionResolver
+}
+
+export class A2AExpressService {
+    private requestHandler: A2ARequestHandler; // Kept for getAgentCard
+    private jsonRpcTransportHandler: JsonRpcTransportHandler;
+    private options: A2AServiceOptions;
+
+    constructor(requestHandler: A2ARequestHandler, options?: A2AServiceOptions) {
+        this.requestHandler = requestHandler; // DefaultRequestHandler instance
+        this.jsonRpcTransportHandler = new JsonRpcTransportHandler(requestHandler);
+        this.options = options;
+    }
+
+    public cardEndpoint = async (req: Request, res: Response) => {
+        try {
+            // resolve agent service endpoint
+            let url: string;
+            if (this.options?.agentPath) {
+                url = `${req.protocol}://${req.get('host')}${this.options.agentPath}`;
+            } else {
+                /* If there's no explicit agent path, then derive one from the Express
+                 Request originalUrl by removing the trailing /agent.json if present */
+                const baseUrl = req.originalUrl.replace(/\/agent\.json$/, '');
+                url = `${req.protocol}://${req.get('host')}${baseUrl}`;
+            }
+            console.log( "url", url );
+
+            const agentCard = await this.requestHandler.getAgentCard();
+            res.json({...agentCard, url});
+        } catch (error: any) {
+            console.error("Error fetching agent card:", error);
+            res.status(500).json({ error: "Failed to retrieve agent card" });
+        }
+    }
+
+    public agentEndpoint = async (req: Request, res: Response) => {
+        try {
+            // Handle client authentication
+            let agentSession: ClientAgentSession | null = null;
+            if( this.options?.agentSessionResolver ) {
+                agentSession = await this.options.agentSessionResolver( req, res );
+                if( !agentSession )
+                    return; // 401 response with challenge already issued
+            }
+
+            const rpcResponseOrStream = await this.jsonRpcTransportHandler.handle(req.body);
+
+            // Check if it's an AsyncGenerator (stream)
+            if (typeof (rpcResponseOrStream as any)?.[Symbol.asyncIterator] === 'function') {
+                const stream = rpcResponseOrStream as AsyncGenerator<JSONRPCSuccessResponse, void, undefined>;
+
+                res.setHeader('Content-Type', 'text/event-stream');
+                res.setHeader('Cache-Control', 'no-cache');
+                res.setHeader('Connection', 'keep-alive');
+                res.flushHeaders();
+
+                try {
+                    for await (const event of stream) {
+                        // Each event from the stream is already a JSONRPCResult
+                        res.write(`id: ${new Date().getTime()}\n`);
+                        res.write(`data: ${JSON.stringify(event)}\n\n`);
+                    }
+                } catch (streamError: any) {
+                    console.error(`Error during SSE streaming (request ${req.body?.id}):`, streamError);
+                    // If the stream itself throws an error, send a final JSONRPCErrorResponse
+                    const a2aError = streamError instanceof A2AError ? streamError : A2AError.internalError(streamError.message || 'Streaming error.');
+                    const errorResponse: JSONRPCErrorResponse = {
+                        jsonrpc: '2.0',
+                        id: req.body?.id || null, // Use original request ID if available
+                        error: a2aError.toJSONRPCError(),
+                    };
+                    if (!res.headersSent) { // Should not happen if flushHeaders worked
+                        res.status(500).json(errorResponse); // Should be JSON, not SSE here
+                    } else {
+                        // Try to send as last SSE event if possible, though client might have disconnected
+                        res.write(`id: ${new Date().getTime()}\n`);
+                        res.write(`event: error\n`); // Custom event type for client-side handling
+                        res.write(`data: ${JSON.stringify(errorResponse)}\n\n`);
+                    }
+                } finally {
+                    if (!res.writableEnded) {
+                        res.end();
+                    }
+                }
+            } else { // Single JSON-RPC response
+                const rpcResponse = rpcResponseOrStream as A2AResponse;
+                res.status(200).json(rpcResponse);
+            }
+        } catch (error: any) { // Catch errors from jsonRpcTransportHandler.handle itself (e.g., initial parse error)
+            console.error("Unhandled error in A2AExpressApp POST handler:", error);
+            const a2aError = error instanceof A2AError ? error : A2AError.internalError('General processing error.');
+            const errorResponse: JSONRPCErrorResponse = {
+                jsonrpc: '2.0',
+                id: req.body?.id || null,
+                error: a2aError.toJSONRPCError(),
+            };
+            if (!res.headersSent) {
+                res.status(500).json(errorResponse);
+            } else if (!res.writableEnded) {
+                // If headers sent (likely during a stream attempt that failed early), try to end gracefully
+                res.end();
+            }
+        }
+    }
+
+    /**
+     * Adds A2A routes to an existing Express app.
+     * @param app Optional existing Express app.
+     * @param baseUrl The base URL for A2A endpoints (e.g., "/a2a/api").
+     * @returns The Express app with A2A routes.
+     */
+    public routes(): Router {
+        const router = Router();
+
+        router.get("/agent.json", this.cardEndpoint );
+
+        router.post("/", this.agentEndpoint );
+
+        // The separate /stream endpoint is no longer needed.
+        return router;
+    }
+}
+
+/**
+  * If an authorization header is provided, then an attemot to resolve an agent session is made,
+  * otherwise a 401 response with a new challenge in the WWW-Authenticate header.
+  * @returns a ClientAgentSession, or null if request handled by 401/challenge
+  * @throws {Error} if authorization header is invalid.  If authorization is expired or not
+  *   found, then no error is thrown and instead a new challenge is issued.
+  */ 
+export async function resolveAgentSession(
+    req: Request,
+    res: Response,
+    store: ClientAgentSessionStore,
+    didResolver: Resolver
+): Promise<ClientAgentSession | null> {
+    const { authorization } = req.headers;
+    if( authorization ) {
+        const agentSession = await handleAuthorization( authorization, store, didResolver );
+        if( agentSession )
+            return agentSession;
+    }
+
+    const challenge = await createChallenge( store );
+    res.status(401)
+        .set('WWW-Authenticate', `Agentic ${b64u.objectToBase64Url(challenge)}`)
+        .end();
+    return null;  
+}


### PR DESCRIPTION
This PR adds Decentralized ID (DID)/JWT based authentication and user, business, and gov scoped identity to A2A agents.  While DIDs can support DLT, this implementation is web based and all DID documents are accessible via HTTP(S).

# What is this solving?

While most agent orchestration frameworks authenticate with remote agents using API keys as bearer tokens or user driven OAuth, there is a big gap in the ability of two different entities agents being able to authenticate.  For example, if you and I are attending the same event and we should really meet to discuss the **next big thing**, then how does an agent representing you find an agent representing me, and then how to they authenticate each other, and start a dialog to determine your and my synergies?

Having a DID associated with you, and a DID for me is the first step.  A presence service can then see we are nearby.  We can resolve DID documents from our DIDs which in turn list the agents representing us.  Public key cryptography obviates authentication servers as the DID document contains the public keys.  Standard HTTP 401/WWW-Authenticate header with challenge provides a very well established and secure way for agents to establish secure communications.

# Design

The Agentic Profile is a very thin wrapper around DIDs and A2A that supports the above interaction.  I've modified the A2A server to accept an AgentSessionResolver for use when agents require authentication.  A working example is in the eliza-app.ts file.

I also modified the A2AClient to accept an authHandler option which intercepts HTTP 401 responses and can inject the WWW-Authenticate header.  I added support for two more parameters to the CLI to indicate which authentication profile to use, and which agent from that profile to use to generate the JWT.

Finally, I added a utility script at scripts/create-global-agentic-profile to publish a demo agentic profile to the public web for testing.  A local copy of the private keys for that profile are stored at ~/.agentic/iam

Much more information is available on my [Agentic Profile blog](https://agenticprofile.ai) and also in the NPM agentic profile packages:

- [@agentic-profile/auth](https://www.npmjs.com/package/@agentic-profile/auth)
- [@agentic-profile/a2a](https://www.npmjs.com/package/@agentic-profile/a2a)

Thank you!

